### PR TITLE
Update half-pipe to use matchdep

### DIFF
--- a/examples/rails/Gruntfile.js
+++ b/examples/rails/Gruntfile.js
@@ -1,6 +1,7 @@
 /*global module:false*/
 module.exports = function(grunt) {
 
+  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 
   // Project configuration.
   grunt.initConfig({
@@ -48,14 +49,6 @@ module.exports = function(grunt) {
     clean: ['public/assets/', 'tmp/']
 
   });
-
-  // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-sass');
-  grunt.loadNpmTasks('grunt-contrib-cssmin');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-requirejs');
 
   // Default task.
   grunt.registerTask('default', 'build');

--- a/examples/rails/package.json
+++ b/examples/rails/package.json
@@ -3,13 +3,14 @@
   "devDependencies": {
     "grunt-cli": "~0.1.7",
     "grunt": "~0.4.1",
-    "bower": "~0.9.2",
+    "bower": "~1.0.0",
     "grunt-contrib-sass": "~0.3.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-jshint": "~0.4.3",
     "grunt-contrib-cssmin": "~0.6.0",
-    "grunt-contrib-requirejs": "~0.4.0"
+    "grunt-requirejs": "~0.3.5",
+    "matchdep": "~0.1.2"
   }
 }
 

--- a/lib/generators/half_pipe/templates/Gruntfile.js
+++ b/lib/generators/half_pipe/templates/Gruntfile.js
@@ -1,6 +1,7 @@
 /*global module:false*/
 module.exports = function(grunt) {
 
+  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 
   // Project configuration.
   grunt.initConfig({
@@ -46,14 +47,6 @@ module.exports = function(grunt) {
     clean: ['public/scripts/', 'public/styles', 'tmp/']
 
   });
-
-  // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-sass');
-  grunt.loadNpmTasks('grunt-contrib-cssmin');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-requirejs');
 
   // Default task.
   grunt.registerTask('default', 'build');

--- a/lib/generators/half_pipe/templates/package.json
+++ b/lib/generators/half_pipe/templates/package.json
@@ -9,7 +9,8 @@
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-jshint": "~0.4.3",
     "grunt-contrib-cssmin": "~0.6.0",
-    "grunt-requirejs": "~0.3.5"
+    "grunt-requirejs": "~0.3.5",
+    "matchdep": "~0.1.2"
   }
 }
 


### PR DESCRIPTION
This removes the need to manually add and
remove `grunt.loadNpmTasks`.
