### PR TITLE
Make half-pipe compatible with rails-api

### DIFF
--- a/lib/generators/half_pipe/install_generator.rb
+++ b/lib/generators/half_pipe/install_generator.rb
@@ -25,13 +25,17 @@ module HalfPipe
         railties_requires = File.read(File.join(self.class.source_root, "railties.rb"))
         gsub_file "config/application.rb", %r{require 'rails/all'}, railties_requires
 
-        gsub_file "app/views/layouts/application.html.erb", %r{\s*<%= stylesheet_link_tag\s+"application".*%>$}, ''
-        gsub_file "app/views/layouts/application.html.erb", %r{\s*<%= javascript_include_tag\s+"application".*%>$}, ''
+        if test ?f, "app/views/layouts/application.html.erb"
+          gsub_file "app/views/layouts/application.html.erb", %r{\s*<%= stylesheet_link_tag\s+"application".*%>$}, ''
+          gsub_file "app/views/layouts/application.html.erb", %r{\s*<%= javascript_include_tag\s+"application".*%>$}, ''
+        end
       end
 
       def insert_includes_into_layout
-        insert_into_file "app/views/layouts/application.html.erb", %Q{  <%= javascript_include_tag "/assets/scripts/application.js" %>\n  }, before: "</body>"
-        insert_into_file "app/views/layouts/application.html.erb", %Q{  <%= stylesheet_link_tag "/assets/styles/main" %>\n  }, before: "</head>"
+        if test ?f, "app/views/layouts/application.html.erb"
+          insert_into_file "app/views/layouts/application.html.erb", %Q{  <%= javascript_include_tag "/assets/scripts/application.js" %>\n  }, before: "</body>"
+          insert_into_file "app/views/layouts/application.html.erb", %Q{  <%= stylesheet_link_tag "/assets/styles/main" %>\n  }, before: "</head>"
+        end
       end
 
       def generate_scripts


### PR DESCRIPTION
The rails-api gem creates projects that don't have any views.  Calling insert_into_file without checking first leads to this crash:

```
$ bin/rails g half_pipe:install
Installing using sass
      create  package.json
      create  .bowerrc
      create  bower.json
      create  .jshintrc
      create  Gruntfile.js
      create  config/half-pipe.json
        gsub  config/application.rb
        gsub  config/application.rb
        gsub  app/views/layouts/application.html.erb
/Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:231:in `binread': No such file or directory @ rb_sysopen - /Users/bronson/oweto/app/views/layouts/application.html.erb (Errno::ENOENT)
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:231:in `gsub_file'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/half-pipe-35f6b1b26b8a/lib/generators/half_pipe/install_generator.rb:28:in `remove_sprockets'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `block in invoke_all'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `each'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `map'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `invoke_all'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/group.rb:232:in `dispatch'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.4/lib/rails/generators.rb:157:in `invoke'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.4/lib/rails/commands/generate.rb:11:in `<top (required)>'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:247:in `require'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:247:in `block in require'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:232:in `load_dependency'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:247:in `require'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.4/lib/rails/commands/commands_tasks.rb:135:in `generate_or_destroy'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.4/lib/rails/commands/commands_tasks.rb:51:in `generate'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.4/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/railties-4.1.4/lib/rails/commands.rb:17:in `<top (required)>'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:247:in `require'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:247:in `block in require'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:232:in `load_dependency'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:247:in `require'
    from /Users/bronson/oweto/bin/rails:8:in `<top (required)>'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:241:in `load'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:241:in `block in load'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:232:in `load_dependency'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.4/lib/active_support/dependencies.rb:241:in `load'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/bronson/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from -e:1:in `<main>'
```
