### PR TITLE
ensure .gitignore ends in a newline

### DIFF
--- a/lib/generators/half_pipe/install_generator.rb
+++ b/lib/generators/half_pipe/install_generator.rb
@@ -50,7 +50,7 @@ module HalfPipe
       end
 
       def insert_ignores
-        append_to_file ".gitignore", %w(node_modules bower_components public/assets/* !public/assets/images).join("\n"), force: true
+        append_to_file ".gitignore", %w(node_modules bower_components public/assets/* !public/assets/images).join("\n")+"\n", force: true
       end
 
       def generate_task_config_files


### PR DESCRIPTION
If .gitignore doesn't end in a newline then appending to it won't work well.  I discovered this when I ran `rails g half_pipe:install`, then ran `rails g half_pipe:install --processor=less` to correct it.

I ended up with this in my .gitignore:

```
/log/*.log
/tmp
node_modules
bower_components
public/assets/*
!public/assets/imagesnode_modules                           <-- missing newline
bower_components
public/assets/*
!public/assets/images
```

Of course, it would be nice if the generator didn't add lines that are already in the file.
