### PR TITLE
make cssmin operate on the generated file

### DIFF
--- a/lib/generators/half_pipe/templates/tasks/options/cssmin.js
+++ b/lib/generators/half_pipe/templates/tasks/options/cssmin.js
@@ -6,9 +6,7 @@ module.exports = {
       report: 'min',
       selectorsMergeMode: 'ie8'
     },
-    src: [
-      'tmp/styles/main.css'
-    ],
-    dest: 'public/styles/main.css'
+    src: '<%= dirs.tmp %>/public/assets/styles/main.css',
+    dest: '<%= dirs.tmp %>/public/assets/styles/main.css'
   }
 };


### PR DESCRIPTION
Both sass and less put their results in dirs.tmp.  That's also where the copy:finalize task expects to find the final result.  Therefore, make cssmin operate on the main.css file in-place.

Without this change, cssmin always seems to complain:

```
Running "cssmin:compress" (cssmin) task
>> Destination not written because minified CSS was empty.
```
