### PR TITLE
also clean public/assets output dir

### DIFF
--- a/lib/generators/half_pipe/templates/Gruntfile.js
+++ b/lib/generators/half_pipe/templates/Gruntfile.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
     copy: config("copy"),
     watch: config("watch"),
     rails: config("rails"),
-    clean: ['<%%= dirs.tmp %>']
+    clean: ['<%%= dirs.tmp %>', 'public/assets']
   });
 
   // Default task.


### PR DESCRIPTION
If the output directory doesn't get cleaned before generating the files, there's a good chance that an error or misconfiguration could leave you with inconsistent files.
