### PR TITLE
ensure build:debug results are copied to public

### DIFF
--- a/lib/generators/half_pipe/templates/Gruntfile.js
+++ b/lib/generators/half_pipe/templates/Gruntfile.js
@@ -35,8 +35,8 @@ module.exports = function(grunt) {
   // Configure asset building pipeline
   grunt.registerTask('build', ['build:debug']);
   <% if options.processor == 'less' %>
-  grunt.registerTask('build:debug', ['clean', 'copy:prepare', 'requirejs:debug', 'less:debug']);
-  grunt.registerTask('build:public', ['clean', 'copy:prepare', 'requirejs:public', 'less:public', 'cssmin:compress' ,'copy:finalize']);  
+  grunt.registerTask('build:debug', ['clean', 'copy:prepare', 'requirejs:debug', 'less:debug', 'copy:finalize']);
+  grunt.registerTask('build:public', ['clean', 'copy:prepare', 'requirejs:public', 'less:public', 'cssmin:compress' ,'copy:finalize']);
   <% else %>
   grunt.registerTask('build:debug', ['clean', 'copy:prepare', 'requirejs:debug', 'sass:debug']);
   grunt.registerTask('build:public', ['clean', 'copy:prepare', 'requirejs:public', 'sass:public', 'copy:finalize']);


### PR DESCRIPTION
Without this change, build:debug leaves its results in tmp/half-pipe/public/assets.  They need to be copied to public/assets to be usable.
