### PR TITLE
move 'use strict' out of global scope

### DIFF
--- a/lib/generators/half_pipe/templates/app/scripts/main.js
+++ b/lib/generators/half_pipe/templates/app/scripts/main.js
@@ -1,5 +1,3 @@
-'use strict';
-
 define('<%= main_module_name %>',
   [
     // Add your dependencies here
@@ -8,6 +6,7 @@ define('<%= main_module_name %>',
   ],
 
   function($){
+    'use strict';
 
       // Add your initialization code here
 


### PR DESCRIPTION
If it's in global scope and minimized, it can mess up files concatenated after.

This change also fixes jshint's complaints about main.js.  More discussion about this, fwiw: http://www.yuiblog.com/blog/2010/12/14/strict-mode-is-coming-to-town/
