### PR TITLE
watch app/views and livereload by default

### DIFF
--- a/lib/generators/half_pipe/templates/tasks/options/watch.js
+++ b/lib/generators/half_pipe/templates/tasks/options/watch.js
@@ -1,7 +1,10 @@
 module.exports = {
   debug: {
-    files: ['app/scripts/**/*', 'app/styles/**/*', 'config/build.js'],
-    tasks: ['build:debug']
+    files: ['app/views/**/*', 'app/scripts/**/*', 'app/styles/**/*', 'config/build.js'],
+    tasks: ['build:debug'],
+    options: {
+      livereload: true
+    }
   },
   rails: {
     files: ['config/**/*.rb', 'lib/**/*.rb', 'Gemfile.lock'],


### PR DESCRIPTION
Minor suggestions for the default behavior of the generator:
- [x] enable livereload
- [x] watch not just styles and scripts, but views as well
